### PR TITLE
Mirror of curl curl PR IssueNumber 5972

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1864,8 +1864,8 @@ static CURLcode ftp_state_pasv_resp(struct connectdata *conn,
   else if((ftpc->count1 == 1) &&
           (ftpcode == 227)) {
     /* positive PASV response */
-    unsigned int ip[4];
-    unsigned int port[2];
+    unsigned int ip[4] = {0, 0, 0, 0};
+    unsigned int port[2] = {0, 0};
 
     /*
      * Scan for a sequence of six comma-separated numbers and use them as


### PR DESCRIPTION
Mirror of curl curl PR IssueNumber 5972
If the received PASV response doesn't match the expected pattern, we
could end up reading uninitialized integers for IP address and port
number.

Issue pointed out by muse.dev
